### PR TITLE
Use appropriate executable extension for the platform

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,21 +13,21 @@ OCAMLOPT = ocamlopt
 COMPFLAGS = -w +A-4-17-44-45 -I +compiler-libs
 
 .PHONY: all
-all: genlifter.exe dumpast.exe ppx_metaquot.exe ast_mapper_class.cmo ppx_tools.cma
+all: genlifter$(EXE) dumpast$(EXE) ppx_metaquot$(EXE) ast_mapper_class.cmo ppx_tools.cma
 all: ppx_tools.cmxa
 
-genlifter.exe: ppx_tools.cma genlifter.cmo
-	$(OCAMLC) $(COMPFLAGS) -o genlifter.exe ocamlcommon.cma ppx_tools.cma genlifter.cmo
+genlifter$(EXE): ppx_tools.cma genlifter.cmo
+	$(OCAMLC) $(COMPFLAGS) -o genlifter$(EXE) ocamlcommon.cma ppx_tools.cma genlifter.cmo
 
-dumpast.exe: dumpast.cmo
-	$(OCAMLC) $(COMPFLAGS) -o dumpast.exe ocamlcommon.cma ocamlbytecomp.cma ast_lifter.cmo dumpast.cmo
+dumpast$(EXE): dumpast.cmo
+	$(OCAMLC) $(COMPFLAGS) -o dumpast$(EXE) ocamlcommon.cma ocamlbytecomp.cma ast_lifter.cmo dumpast.cmo
 
 
-ppx_metaquot.exe: ppx_metaquot.cmo
-	$(OCAMLC) $(COMPFLAGS) -o ppx_metaquot.exe ocamlcommon.cma ppx_tools.cma ast_lifter.cmo ppx_metaquot.cmo
+ppx_metaquot$(EXE): ppx_metaquot.cmo
+	$(OCAMLC) $(COMPFLAGS) -o ppx_metaquot$(EXE) ocamlcommon.cma ppx_tools.cma ast_lifter.cmo ppx_metaquot.cmo
 
-ast_lifter.ml: genlifter.exe
-	./genlifter.exe -I +compiler-libs Parsetree.expression > ast_lifter.ml || rm -rf ast_lifter.ml
+ast_lifter.ml: genlifter$(EXE)
+	./genlifter$(EXE) -I +compiler-libs Parsetree.expression > ast_lifter.ml || rm -rf ast_lifter.ml
 
 
 OBJS = ast_convenience.cmo ast_mapper_class.cmo
@@ -47,7 +47,8 @@ depend:
 
 .PHONY: clean
 clean:
-	rm -f *.cm* *.exe *~ *.o *.obj *.a *.lib *.tar.gz
+	rm -f *.cm* *~ *.o *.obj *.a *.lib *.tar.gz
+	rm -f genlifter$(EXE) dumpast$(EXE) ppx_metaquot$(EXE)
 	rm -f ast_lifter.ml
 
 # Default rules
@@ -67,7 +68,7 @@ clean:
 # Install/uninstall
 
 INSTALL = META \
-   genlifter.exe dumpast.exe ppx_metaquot.exe \
+   genlifter$(EXE) dumpast$(EXE) ppx_metaquot$(EXE) \
    ppx_tools.cma ppx_tools.cmxa ppx_tools$(EXT_LIB) \
    ast_convenience.cmi ast_convenience.cmx \
    ast_mapper_class.cmi ast_mapper_class.cmx

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ Ast_mapper is that Ast_mapper_class implements the open recursion
 using a class.
 
 
-dumpast.exe
------------
+dumpast
+-------
 
 This tool parses fragments of OCaml code (or entire source files) and
 dump the resulting internal Parsetree representation.  Intended uses:
@@ -34,8 +34,8 @@ dump the resulting internal Parsetree representation.  Intended uses:
    code of syntax-manipulating programs (such as ppx rewriters).
 
 Usage:
- 
-  ocamlfind ppx_tools/dumpast.exe -e "1 + 2"
+
+    ocamlfind ppx_tools/dumpast -e "1 + 2"
 
 The tool can be used to show the Parsetree representation of small
 fragments of syntax passed on the command line (-e for expressions, -p
@@ -45,8 +45,8 @@ whole files.  The tool has further option to control how location and
 attribute fields in the Parsetree should be displayed.
 
 
-ppx_metaquot.exe
-----------------
+ppx_metaquot
+------------
 
 A ppx filter to help writing programs which manipulate the Parsetree,
 by allowing the programmer to use concrete syntax for expressions
@@ -56,12 +56,11 @@ supported extensions.
 
 Usage:
 
-  ocamlfind -c -ppx "ocamlfind ppx_tools/ppx_metaquot.exe" my_ppx_code.ml
+    ocamlfind -c -ppx "ocamlfind ppx_tools/ppx_metaquot" my_ppx_code.ml
 
 
-
-genlifter.exe
--------------
+genlifter
+---------
 
 This tool generates a virtual "lifter" class for one or several OCaml
 type constructors.  It does so by loading the .cmi files which define
@@ -73,7 +72,7 @@ with basic types (int, string, char, int32, int64, nativeint) and data
 type builders (record, constr, tuple, list, array).  As an example,
 calling:
 
-    ocamlfind ppx_tools/genlifter.exe -I +compiler-libs Location.t
+    ocamlfind ppx_tools/genlifter -I +compiler-libs Location.t
 
 produces the following class:
 
@@ -103,7 +102,7 @@ produces the following class:
               ("pos_bol", (this#int pos_bol));
               ("pos_cnum", (this#int pos_cnum))]
       end
-    
-dumpast.exe is a direct example of using genlifter.exe applied on the
+
+_dumpast_ is a direct example of using _genlifter_ applied on the
 OCaml Parsetree definition itself.  ppx_metaquot.exe is another
 similar example.


### PR DESCRIPTION
This PR does not require the user to decide between invoking `command` and `command.exe`, as findlib automatically adds the `.exe` extension if it is required.

While the change may appear merely cosmetic, I think it is very important to follow existing conventions on all of the target platforms.
