### PR TITLE
Restore compatibility with 4.02

### DIFF
--- a/dumpast.ml
+++ b/dumpast.ml
@@ -57,10 +57,10 @@ let show_file fn =
   Compenv.readenv Format.err_formatter Compenv.Before_compile;
   let v =
     if Filename.check_suffix fn ".mli" then
-      let ast = Pparse.parse_interface Format.err_formatter fn in
+      let ast = Pparse.parse_interface ~tool_name:"ocamlc" Format.err_formatter fn in
       lift # lift_Parsetree_signature ast
     else if Filename.check_suffix fn ".ml" then
-      let ast = Pparse.parse_implementation Format.err_formatter fn in
+      let ast = Pparse.parse_implementation ~tool_name:"ocamlc" Format.err_formatter fn in
       lift # lift_Parsetree_structure ast
     else
       failwith (Printf.sprintf "Don't know what to do with file %s" fn)


### PR DESCRIPTION
Please also cut a release; right now, pretty much all ppx-related packages will fail to install.
