### PR TITLE
ppx_tools for modular-implicits compiler

### DIFF
--- a/ast_convenience.ml
+++ b/ast_convenience.ml
@@ -26,8 +26,9 @@ let float x = Exp.constant (Const_float (string_of_float x))
 let record ?over l =
   Exp.record (List.map (fun (s, e) -> (lid s, e)) l) over
 let func l = Exp.function_ (List.map (fun (p, e) -> Exp.case p e) l)
-let lam ?(label = Asttypes.Nolabel) ?default pat exp = Exp.fun_ label default pat exp
-let app f l = if l = [] then f else Exp.apply f (List.map (fun a -> Asttypes.Nolabel, a) l)
+let lam ?(label = Parsetree.Parr_simple) ?default pat exp = Exp.fun_ label default pat exp
+let app f l = if l = [] then f else Exp.apply f (List.map (fun a ->
+  Parsetree.Papp_simple, a) l)
 let evar s = Exp.ident (lid s)
 let let_in ?(recursive = false) b body =
   Exp.let_ (if recursive then Recursive else Nonrecursive) b body

--- a/ast_convenience.mli
+++ b/ast_convenience.mli
@@ -28,7 +28,7 @@ val list: expression list -> expression
 val unit: unit -> expression
 
 val func: (pattern * expression) list -> expression
-val lam: ?label:Asttypes.arg_label -> ?default:expression -> pattern -> expression -> expression
+val lam: ?label:Parsetree.arrow_flag -> ?default:expression -> pattern -> expression -> expression
 val app: expression -> expression list -> expression
 
 val str: string -> expression

--- a/ast_mapper_class.ml
+++ b/ast_mapper_class.ml
@@ -290,10 +290,8 @@ module E = struct
     | Pexp_override sel ->
         override ~loc ~attrs
                  (List.map (map_tuple (map_loc sub) (sub # expr)) sel)
-    (*
-     *| Pexp_letmodule (me, e) ->
-     *    letmodule ~loc ~attrs (sub # module_expr me) (sub # expr e)
-     *)
+    | Pexp_letmodule (me, e) ->
+        letmodule ~loc ~attrs (sub # module_binding me) (sub # expr e)
     | Pexp_assert e -> assert_ ~loc ~attrs (sub # expr e)
     | Pexp_lazy e -> lazy_ ~loc ~attrs (sub # expr e)
     | Pexp_poly (e, t) ->
@@ -304,7 +302,6 @@ module E = struct
     | Pexp_open (ovf, lid, e) ->
         open_ ~loc ~attrs ovf (map_loc sub lid) (sub # expr e)
     | Pexp_extension x -> extension ~loc ~attrs (sub # extension x)
-    | _ -> assert false
 end
 
 module P = struct

--- a/ast_mapper_class.mli
+++ b/ast_mapper_class.mli
@@ -21,7 +21,6 @@ class mapper:
     method class_type: class_type -> class_type
     method class_type_declaration: class_type_declaration -> class_type_declaration
     method class_type_field: class_type_field -> class_type_field
-    method constructor_arguments: constructor_arguments -> constructor_arguments
     method constructor_declaration: constructor_declaration -> constructor_declaration
     method expr: expression -> expression
     method extension: extension -> extension

--- a/genlifter.ml
+++ b/genlifter.ml
@@ -54,11 +54,11 @@ let rec gen ty =
   let params = List.mapi (fun i _ -> Printf.sprintf "f%i" i) td.type_params in
   let env = List.map2 (fun s t -> t.id, evar s) params td.type_params in
   let tyargs = List.map (fun t -> Typ.var t) params in
-  let t = Typ.(arrow Asttypes.Nolabel (constr (lid ty) tyargs) (var "res")) in
+  let t = Typ.(arrow Parsetree.Parr_simple (constr (lid ty) tyargs) (var "res")) in
   let t =
     List.fold_right
       (fun s t ->
-        Typ.(arrow Asttypes.Nolabel (arrow Asttypes.Nolabel (var s) (var "res")) t))
+        Typ.(arrow Parsetree.Parr_simple (arrow Parsetree.Parr_simple (var s) (var "res")) t))
       params t
   in
   let t = Typ.poly params t in
@@ -83,15 +83,9 @@ let rec gen ty =
       let case cd =
         let c = Ident.name cd.cd_id in
         let qc = prefix ^ c in
-        match cd.cd_args with
-        | Cstr_tuple (tys) ->
-          let p, args = gentuple env tys in
-          pconstr qc p, selfcall "constr" [str ty; tuple[str c; list args]]
-        | Cstr_record (l) ->
-          let l = List.map field l in
-          pconstr qc [Pat.record (List.map fst l) Closed],
-          selfcall "constr" [str ty; tuple [str c;
-            selfcall "record" [str (ty ^ "." ^ c); list (List.map snd l)]]]
+
+        let p, args = gentuple env cd.cd_args in
+        pconstr qc p, selfcall "constr" [str ty; tuple[str c; list args]]
       in
       concrete (func (List.map case l))
   | Type_abstract, Some t ->
@@ -157,12 +151,12 @@ let simplify =
     let open Parsetree in
     match e.pexp_desc with
     | Pexp_fun
-        (Asttypes.Nolabel, None,
+        (Parsetree.Parr_simple, None,
          {ppat_desc = Ppat_var{txt=id;_};_},
          {pexp_desc =
             Pexp_apply
               (f,
-               [Asttypes.Nolabel
+               [Parsetree.Papp_simple
                ,{pexp_desc= Pexp_ident{txt=Lident id2;_};_}]);_})
          when id = id2 -> f
     | _ -> e


### PR DESCRIPTION
Some changes were needed for the modular-implicits compiler.
(https://github.com/ocamllabs/ocaml-modular-implicits)  

Is there any possibility to create a branch, keeping compatibility, 
and sending a special version of ppx_tools for this compiler ?