### PR TITLE
Add string delimiter compatibility wrapper.

### DIFF
--- a/ast_convenience.ml
+++ b/ast_convenience.ml
@@ -76,6 +76,10 @@ let get_str = function
   | {pexp_desc=Pexp_constant (Pconst_string (s, _)); _} -> Some s
   | _ -> None
 
+let get_str_with_quotation_delimiter = function
+  | {pexp_desc=Pexp_constant (Pconst_string (s, d)); _} -> Some (s, d)
+  | _ -> None
+
 let get_lid = function
   | {pexp_desc=Pexp_ident{txt=id;_};_} ->
       Some (String.concat "." (Longident.flatten id))

--- a/ast_convenience.mli
+++ b/ast_convenience.mli
@@ -83,6 +83,7 @@ val tconstr: string -> core_type list -> core_type
 (** {2 AST deconstruction} *)
 
 val get_str: expression -> string option
+val get_str_with_quotation_delimiter: expression -> (string * string option) option
 val get_lid: expression -> string option
 
 val has_attr: string -> attributes -> bool


### PR DESCRIPTION
Would be quite helpful for https://github.com/ocsigen/tyxml/pull/89. In particular, see: https://github.com/ocsigen/tyxml/blob/ppx/ppx/ppx_tyxml.ml#L177