### PR TITLE
Add Asttypes.constant abstractions to ppx_tools.

### DIFF
--- a/ast_convenience.ml
+++ b/ast_convenience.ml
@@ -28,11 +28,7 @@ module Label = struct
 
 end
 
-module Constant = struct 
-  let get_char = function Const_char c -> Some c | _ -> None 
-  let get_int = function Const_int i -> Some i | _ -> None
-  let get_str = function Const_string(s, _) -> Some s | _ -> None 
-end 
+let constant_type c = c 
 
 let may_tuple tup = function
   | [] -> None

--- a/ast_convenience.ml
+++ b/ast_convenience.ml
@@ -33,7 +33,22 @@ module Constant = struct
      Pconst_integer of string * char option 
    | Pconst_char of char 
    | Pconst_string of string * string option 
-   | Pconst_float of string * char option 
+   | Pconst_float of string * char option
+
+  exception Unknown_literal of string * char 
+
+  (** Backport Int_literal_converter from ocaml 4.03 - 
+   * https://github.com/ocaml/ocaml/blob/trunk/utils/misc.ml#L298 *)
+  module Int_literal_converter = struct 
+    let cvt_int_aux str neg of_string = 
+      if String.length str = 0 || str.[0] = '-'
+      then of_string str 
+      else neg (of_string ("-" ^ str))
+    let int s = cvt_int_aux s (~-) int_of_string 
+    let int32 s = cvt_int_aux s Int32.neg Int32.of_string 
+    let int64 s = cvt_int_aux s Int64.neg Int64.of_string 
+    let nativeint s = cvt_int_aux s Nativeint.neg Nativeint.of_string 
+  end 
 
   let of_constant = function       
     | Asttypes.Const_int32(i) -> Pconst_integer(Int32.to_string i, Some 'l')
@@ -45,14 +60,15 @@ module Constant = struct
     | Asttypes.Const_float f -> Pconst_float(f, None)
 
   let to_constant = function 
-    | Pconst_integer(s, Some 'l') -> Asttypes.Const_int32 (Int32.of_string s)
-    | Pconst_integer(s, Some 'L') -> Asttypes.Const_int64 (Int64.of_string s)
-    | Pconst_integer(s, Some 'n') -> Asttypes.Const_nativeint (Nativeint.of_string s)
-    | Pconst_integer(s, _ ) -> Asttypes.Const_int (int_of_string s)
+    | Pconst_integer(i,Some 'l') -> Asttypes.Const_int32 (Int_literal_converter.int32 i)
+    | Pconst_integer(i,Some 'L') -> Asttypes.Const_int64 (Int_literal_converter.int64 i)
+    | Pconst_integer(i,Some 'n') -> Asttypes.Const_nativeint (Int_literal_converter.nativeint i)
+    | Pconst_integer(i,None) -> Asttypes.Const_int (Int_literal_converter.int i)
+    | Pconst_integer(i,Some c) -> raise (Unknown_literal (i, c))
     | Pconst_char c -> Asttypes.Const_char c 
-    | Pconst_string(s, s_option) -> Asttypes.Const_string(s, s_option)
-    | Pconst_float(s, _) -> Asttypes.Const_float s
-
+    | Pconst_string(s,d) -> Asttypes.Const_string(s, d)
+    | Pconst_float(f,None) -> Asttypes.Const_float f
+    | Pconst_float(f,Some c) -> raise (Unknown_literal (f, c))
 end   
 
 let may_tuple tup = function

--- a/ast_convenience.ml
+++ b/ast_convenience.ml
@@ -35,7 +35,7 @@ module Constant = struct
    | Pconst_string of string * string option 
    | Pconst_float of string * char option 
 
-  let constant_type = function       
+  let of_constant = function       
     | Asttypes.Const_int32(i) -> Pconst_integer(Int32.to_string i, Some 'l')
     | Asttypes.Const_int64(i) -> Pconst_integer(Int64.to_string i, Some 'L')
     | Asttypes.Const_nativeint(i) -> Pconst_integer(Nativeint.to_string i, Some 'n')
@@ -43,6 +43,15 @@ module Constant = struct
     | Asttypes.Const_char c -> Pconst_char c 
     | Asttypes.Const_string(s, s_opt) -> Pconst_string(s, s_opt) 
     | Asttypes.Const_float f -> Pconst_float(f, None)
+
+  let to_constant = function 
+    | Pconst_integer(s, Some 'l') -> Asttypes.Const_int32 (Int32.of_string s)
+    | Pconst_integer(s, Some 'L') -> Asttypes.Const_int64 (Int64.of_string s)
+    | Pconst_integer(s, Some 'n') -> Asttypes.Const_nativeint (Nativeint.of_string s)
+    | Pconst_integer(s, _ ) -> Asttypes.Const_int (int_of_string s)
+    | Pconst_char c -> Asttypes.Const_char c 
+    | Pconst_string(s, s_option) -> Asttypes.Const_string(s, s_option)
+    | Pconst_float(s, _) -> Asttypes.Const_float s
 
 end   
 

--- a/ast_convenience.ml
+++ b/ast_convenience.ml
@@ -28,6 +28,11 @@ module Label = struct
 
 end
 
+module Constant = struct 
+  let get_char = function Const_char c -> Some c | _ -> None 
+  let get_int = function Const_int i -> Some i | _ -> None
+  let get_str = function Const_string(s, _) -> Some s | _ -> None 
+end 
 
 let may_tuple tup = function
   | [] -> None

--- a/ast_convenience.ml
+++ b/ast_convenience.ml
@@ -28,7 +28,23 @@ module Label = struct
 
 end
 
-let constant_type c = c 
+module Constant = struct 
+  type t = 
+     Pconst_integer of string * char option 
+   | Pconst_char of char 
+   | Pconst_string of string * string option 
+   | Pconst_float of string * char option 
+
+  let constant_type = function       
+    | Asttypes.Const_int32(i) -> Pconst_integer(Int32.to_string i, Some 'l')
+    | Asttypes.Const_int64(i) -> Pconst_integer(Int64.to_string i, Some 'L')
+    | Asttypes.Const_nativeint(i) -> Pconst_integer(Nativeint.to_string i, Some 'n')
+    | Asttypes.Const_int(i) -> Pconst_integer(string_of_int i, None)
+    | Asttypes.Const_char c -> Pconst_char c 
+    | Asttypes.Const_string(s, s_opt) -> Pconst_string(s, s_opt) 
+    | Asttypes.Const_float f -> Pconst_float(f, None)
+
+end   
 
 let may_tuple tup = function
   | [] -> None

--- a/ast_convenience.mli
+++ b/ast_convenience.mli
@@ -26,6 +26,13 @@ module Label : sig
 
 end
 
+(** {2 Deconstruction functions for Asttypes.constant types} *)
+module Constant : sig 
+	val get_char: constant -> char option 
+	val get_int: constant -> int option 
+	val get_str: constant -> string option
+end 
+
 (** {2 Misc} *)
 
 val lid: string -> lid
@@ -85,6 +92,8 @@ val tconstr: string -> core_type list -> core_type
 val get_str: expression -> string option
 val get_str_with_quotation_delimiter: expression -> (string * string option) option
 val get_lid: expression -> string option
+
+(** {AST deconstruction functions for Asttypes.Constant types} *)
 
 val has_attr: string -> attributes -> bool
 val find_attr: string -> attributes -> payload option

--- a/ast_convenience.mli
+++ b/ast_convenience.mli
@@ -33,11 +33,13 @@ module Constant : sig
    | Pconst_char of char 
    | Pconst_string of string * string option 
    | Pconst_float of string * char option 
-  
-  (** Convert Asttypes.constant to Constant.t *)
+
+  exception Unknown_literal of string * char
+
+  (** Converts Asttypes.constant to Constant.t *)
   val of_constant : constant -> t
 
-  (** Convert Constant.t to Asttypes.constant *)
+  (** Converts Constant.t to Asttypes.constant. Raises Unknown_literal if conversion fails *)
   val to_constant : t -> constant 
 end
 

--- a/ast_convenience.mli
+++ b/ast_convenience.mli
@@ -45,7 +45,7 @@ end
 
 val lid: string -> lid
 
-(** {2 Expressions. } *)
+(** {2 Expressions} *)
 
 val evar: string -> expression
 val let_in: ?recursive:bool -> value_binding list -> expression -> expression
@@ -100,8 +100,6 @@ val tconstr: string -> core_type list -> core_type
 val get_str: expression -> string option
 val get_str_with_quotation_delimiter: expression -> (string * string option) option
 val get_lid: expression -> string option
-
-(** {AST deconstruction functions for Asttypes.Constant types} *)
 
 val has_attr: string -> attributes -> bool
 val find_attr: string -> attributes -> payload option

--- a/ast_convenience.mli
+++ b/ast_convenience.mli
@@ -26,18 +26,14 @@ module Label : sig
 
 end
 
-(** {2 Deconstruction functions for Asttypes.constant types} *)
-module Constant : sig 
-	val get_char: constant -> char option 
-	val get_int: constant -> int option 
-	val get_str: constant -> string option
-end 
+(** {2 Provides abstraction over Asttypes.constant type }*)
+val constant_type : constant -> Asttypes.constant
 
 (** {2 Misc} *)
 
 val lid: string -> lid
 
-(** {2 Expressions} *)
+(** {2 Expressions. } *)
 
 val evar: string -> expression
 val let_in: ?recursive:bool -> value_binding list -> expression -> expression

--- a/ast_convenience.mli
+++ b/ast_convenience.mli
@@ -34,8 +34,11 @@ module Constant : sig
    | Pconst_string of string * string option 
    | Pconst_float of string * char option 
   
-  (** Translate ocaml version specific constant type to Constant.t *)
-  val constant_type : constant -> t
+  (** Convert Asttypes.constant to Constant.t *)
+  val of_constant : constant -> t
+
+  (** Convert Constant.t to Asttypes.constant *)
+  val to_constant : t -> constant 
 end
 
 (** {2 Misc} *)

--- a/ast_convenience.mli
+++ b/ast_convenience.mli
@@ -27,7 +27,16 @@ module Label : sig
 end
 
 (** {2 Provides abstraction over Asttypes.constant type }*)
-val constant_type : constant -> Asttypes.constant
+module Constant : sig 
+  type t = 
+     Pconst_integer of string * char option 
+   | Pconst_char of char 
+   | Pconst_string of string * string option 
+   | Pconst_float of string * char option 
+  
+  (** Translate ocaml version specific constant type to Constant.t *)
+  val constant_type : constant -> t
+end
 
 (** {2 Misc} *)
 


### PR DESCRIPTION
@Drup This pull request adds a new function `constant_type` to abstract ocaml AST const types. This is done in relation to and as an offshoot of discussion at [sedlex pull request](https://github.com/alainfrisch/sedlex/pull/37). The latter pull request depends on this pull request. I am sending another pull request for ppx_tools 4.03 branch(master).