### PR TITLE
Redefine constant_type to for ocaml 4.03

### DIFF
--- a/ast_convenience.ml
+++ b/ast_convenience.ml
@@ -25,6 +25,15 @@ module Label = struct
 
 end
 
+  (** : constant -> Asttypes.constant *)
+let constant_type = function 
+  | Pconst_integer(s, Some 'l') -> Asttypes.Const_int32 (Int32.of_string s)
+  | Pconst_integer(s, Some 'L') -> Asttypes.Const_int64 (Int64.of_string s)
+  | Pconst_integer(s, Some 'n') -> Asttypes.Const_nativeint (Nativeint.of_string s)
+  | Pconst_integer(s, _ ) -> Asttypes.Const_int (int_of_string s)
+  | Pconst_char c -> Asttypes.Const_char c 
+  | Pconst_string(s, s_option) -> Asttypes.Const_string(s, s_option)
+  | Pconst_float(s, _) -> Asttypes.Const_float s
 
 let may_tuple ?loc tup = function
   | [] -> None

--- a/ast_convenience.ml
+++ b/ast_convenience.ml
@@ -25,15 +25,15 @@ module Label = struct
 
 end
 
-  (** : constant -> Asttypes.constant *)
-let constant_type = function 
-  | Pconst_integer(s, Some 'l') -> Asttypes.Const_int32 (Int32.of_string s)
-  | Pconst_integer(s, Some 'L') -> Asttypes.Const_int64 (Int64.of_string s)
-  | Pconst_integer(s, Some 'n') -> Asttypes.Const_nativeint (Nativeint.of_string s)
-  | Pconst_integer(s, _ ) -> Asttypes.Const_int (int_of_string s)
-  | Pconst_char c -> Asttypes.Const_char c 
-  | Pconst_string(s, s_option) -> Asttypes.Const_string(s, s_option)
-  | Pconst_float(s, _) -> Asttypes.Const_float s
+module Constant = struct 
+  type t = Parsetree.constant =
+     Pconst_integer of string * char option 
+   | Pconst_char of char 
+   | Pconst_string of string * string option 
+   | Pconst_float of string * char option 
+
+  let constant_type x = x 
+end 
 
 let may_tuple ?loc tup = function
   | [] -> None

--- a/ast_convenience.ml
+++ b/ast_convenience.ml
@@ -32,7 +32,7 @@ module Constant = struct
    | Pconst_string of string * string option 
    | Pconst_float of string * char option 
 
-  let constant_type x = x 
+  let of_constant x = x 
 
   let to_constant x = x
 

--- a/ast_convenience.ml
+++ b/ast_convenience.ml
@@ -33,6 +33,9 @@ module Constant = struct
    | Pconst_float of string * char option 
 
   let constant_type x = x 
+
+  let to_constant x = x
+
 end 
 
 let may_tuple ?loc tup = function

--- a/ast_convenience.mli
+++ b/ast_convenience.mli
@@ -4,9 +4,9 @@
 
 (** {1 Convenience functions to help build and deconstruct AST fragments.} *)
 
-open Parsetree
 open Asttypes
 open Ast_helper
+open Parsetree   (* Open Parsetree after Asttypes since parsetree overrides constant type in 'ocaml 4.03' *)
 
 (** {2 Compatibility modules} *)
 
@@ -25,6 +25,9 @@ module Label : sig
   val optional : string -> t
 
 end
+
+(** {2 Provides abstraction over Asttypes.constant type }*)
+val constant_type : constant -> Asttypes.constant
 
 (** {2 Misc} *)
 

--- a/ast_convenience.mli
+++ b/ast_convenience.mli
@@ -34,11 +34,11 @@ module Constant : sig
    | Pconst_char of char 
    | Pconst_string of string * string option 
    | Pconst_float of string * char option 
-  
-  (** Translate ocaml version specific constant type to Constant.t *)
-  val constant_type : constant -> t
+ 
+  (** Convert Asttypes.constant to Constant.t *) 
+  val of_constant : constant -> t
 
-  (** Translate from Constant.t to constant(Parsetree.constant *)
+  (** Convert Constant.t to Asttypes.constant *)
   val to_constant : t -> constant
 
 end
@@ -96,8 +96,6 @@ val punit: ?loc:loc -> ?attrs:attrs -> unit -> pattern
 (** {2 Types} *)
 
 val tconstr: ?loc:loc -> ?attrs:attrs -> string -> core_type list -> core_type
-
-(** {2 AST deconstruction} *)
 
 val get_str: expression -> string option
 val get_str_with_quotation_delimiter: expression -> (string * string option) option

--- a/ast_convenience.mli
+++ b/ast_convenience.mli
@@ -6,7 +6,7 @@
 
 open Asttypes
 open Ast_helper
-open Parsetree   (* Open Parsetree after Asttypes since parsetree overrides constant type in 'ocaml 4.03' *)
+open Parsetree
 
 (** {2 Compatibility modules} *)
 
@@ -36,10 +36,10 @@ module Constant : sig
    | Pconst_float of string * char option 
  
   (** Convert Asttypes.constant to Constant.t *) 
-  val of_constant : constant -> t
+  val of_constant : Parsetree.constant -> t
 
   (** Convert Constant.t to Asttypes.constant *)
-  val to_constant : t -> constant
+  val to_constant : t -> Parsetree.constant
 
 end
 

--- a/ast_convenience.mli
+++ b/ast_convenience.mli
@@ -27,7 +27,7 @@ module Label : sig
 end
 
 (** {2 Provides a unified abstraction over differences in Parsetree.constant and Asttypes.constant 
- * types defined in ocaml 4.03 and 4.02 respectively. }*)
+ * types defined in ocaml 4.03 and 4.02 respectively}*)
 module Constant : sig 
   type t = Parsetree.constant =
      Pconst_integer of string * char option 
@@ -96,6 +96,8 @@ val punit: ?loc:loc -> ?attrs:attrs -> unit -> pattern
 (** {2 Types} *)
 
 val tconstr: ?loc:loc -> ?attrs:attrs -> string -> core_type list -> core_type
+
+(** {2 AST deconstruction} *)
 
 val get_str: expression -> string option
 val get_str_with_quotation_delimiter: expression -> (string * string option) option

--- a/ast_convenience.mli
+++ b/ast_convenience.mli
@@ -26,8 +26,18 @@ module Label : sig
 
 end
 
-(** {2 Provides abstraction over Asttypes.constant type }*)
-val constant_type : constant -> Asttypes.constant
+(** {2 Provides a unified abstraction over differences in Parsetree.constant and Asttypes.constant 
+ * types defined in ocaml 4.03 and 4.02 respectively. }*)
+module Constant : sig 
+  type t = Parsetree.constant =
+     Pconst_integer of string * char option 
+   | Pconst_char of char 
+   | Pconst_string of string * string option 
+   | Pconst_float of string * char option 
+  
+  (** Translate ocaml version specific constant type to Constant.t *)
+  val constant_type : constant -> t
+end
 
 (** {2 Misc} *)
 

--- a/ast_convenience.mli
+++ b/ast_convenience.mli
@@ -37,6 +37,10 @@ module Constant : sig
   
   (** Translate ocaml version specific constant type to Constant.t *)
   val constant_type : constant -> t
+
+  (** Translate from Constant.t to constant(Parsetree.constant *)
+  val to_constant : t -> constant
+
 end
 
 (** {2 Misc} *)


### PR DESCRIPTION
This is a pull request in relation to 2 other pull request. This one has changes specifically for ocaml version 4.03. 
See.
[sedlex #37 ](https://github.com/alainfrisch/sedlex/pull/37)
[ppx_tools(4.02) 40](https://github.com/alainfrisch/ppx_tools/pull/40)
