### PR TITLE
2016 06 26 compat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ genlifter
 ppx_metaquot
 rewriter
 ast_lifter.ml
+_obuild

--- a/ast_convenience.mli
+++ b/ast_convenience.mli
@@ -10,10 +10,15 @@ open Parsetree
 
 (** {2 Compatibility modules} *)
 
-module Label : sig
-  type t = Asttypes.arg_label
 
+module Label : sig
+#if OCAML_VERSION >= "4.03"
+  type t = Asttypes.arg_label
   type desc = Asttypes.arg_label =
+#else
+  type desc = Asttypes.label
+  type t =
+#endif
       Nolabel
     | Labelled of string
     | Optional of string
@@ -26,20 +31,26 @@ module Label : sig
 
 end
 
-(** {2 Provides a unified abstraction over differences in Parsetree.constant and Asttypes.constant 
- * types defined in ocaml 4.03 and 4.02 respectively}*)
-module Constant : sig 
+(** {2 Provides a unified abstraction over differences in Parsetree.constant and Asttypes.constant types defined in ocaml 4.03 and 4.02 respectively}*)
+module Constant : sig
+#if OCAML_VERSION >= "4.04"
   type t = Parsetree.constant =
-     Pconst_integer of string * char option 
-   | Pconst_char of char 
-   | Pconst_string of string * string option 
-   | Pconst_float of string * char option 
- 
-  (** Convert Asttypes.constant to Constant.t *) 
-  val of_constant : Parsetree.constant -> t
+#else
+  type t =
+#endif
+     Pconst_integer of string * char option
+   | Pconst_char of char
+   | Pconst_string of string * string option
+   | Pconst_float of string * char option
 
+#if OCAML_VERSION >= "4.03"
+  (** Convert Asttypes.constant to Constant.t *)
+  val of_constant : Parsetree.constant -> t
   (** Convert Constant.t to Asttypes.constant *)
   val to_constant : t -> Parsetree.constant
+#else
+  val to_constant : t -> Asttypes.constant
+#endif
 
 end
 

--- a/ast_mapper_class.ml
+++ b/ast_mapper_class.ml
@@ -174,7 +174,11 @@ module MT = struct
     let loc = sub # location loc in
     match desc with
     | Psig_value vd -> value ~loc (sub # value_description vd)
+#if OCAML_VERSION >= "4.03"
     | Psig_type (rf, l) -> type_ ~loc rf (List.map (sub # type_declaration) l)
+#else
+    | Psig_type l -> type_ ~loc (List.map (sub # type_declaration) l)
+#endif
     | Psig_typext te -> type_extension ~loc (sub # type_extension te)
     | Psig_exception ed -> exception_ ~loc (sub # extension_constructor ed)
     | Psig_module x -> module_ ~loc (sub # module_declaration x)
@@ -221,7 +225,11 @@ module M = struct
         eval ~loc ~attrs:(sub # attributes attrs) (sub # expr x)
     | Pstr_value (r, vbs) -> value ~loc r (List.map (sub # value_binding) vbs)
     | Pstr_primitive vd -> primitive ~loc (sub # value_description vd)
+#if OCAML_VERSION >= "4.03"
     | Pstr_type (rf, l) -> type_ ~loc rf (List.map (sub # type_declaration) l)
+#else
+    | Pstr_type l -> type_ ~loc (List.map (sub # type_declaration) l)
+#endif
     | Pstr_typext te -> type_extension ~loc (sub # type_extension te)
     | Pstr_exception ed -> exception_ ~loc (sub # extension_constructor ed)
     | Pstr_module x -> module_ ~loc (sub # module_binding x)
@@ -293,10 +301,12 @@ module E = struct
     | Pexp_letmodule (s, me, e) ->
         letmodule ~loc ~attrs (map_loc sub s) (sub # module_expr me)
           (sub # expr e)
+#if OCAML_VERSION >= "4.04"
     | Pexp_letexception (cd, e) ->
         letexception ~loc ~attrs
           (sub # extension_constructor cd)
           (sub # expr e)
+#endif
     | Pexp_assert e -> assert_ ~loc ~attrs (sub # expr e)
     | Pexp_lazy e -> lazy_ ~loc ~attrs (sub # expr e)
     | Pexp_poly (e, t) ->
@@ -307,7 +317,9 @@ module E = struct
     | Pexp_open (ovf, lid, e) ->
         open_ ~loc ~attrs ovf (map_loc sub lid) (sub # expr e)
     | Pexp_extension x -> extension ~loc ~attrs (sub # extension x)
+#if OCAML_VERSION >= "4.03"
     | Pexp_unreachable -> unreachable ~loc ~attrs ()
+#endif
 end
 
 module P = struct
@@ -339,7 +351,9 @@ module P = struct
     | Ppat_unpack s -> unpack ~loc ~attrs (map_loc sub s)
     | Ppat_exception p -> exception_ ~loc ~attrs (sub # pat p)
     | Ppat_extension x -> extension ~loc ~attrs (sub # extension x)
+#if OCAML_VERSION >= "4.04"
     | Ppat_open (l, p) -> open_ ~loc ~attrs (map_loc sub l) (sub # pat p)
+#endif
 end
 
 module CE = struct
@@ -475,9 +489,13 @@ class mapper =
         ~attrs:(this # attributes pvb_attributes)
         ~loc:(this # location pvb_loc)
 
+#if OCAML_VERSION >= "4.03"
     method constructor_arguments = function
       | Pcstr_tuple (tys) -> Pcstr_tuple (List.map (this # typ) tys)
       | Pcstr_record (ls) -> Pcstr_record (List.map (this # label_declaration) ls)
+#else
+    method constructor_arguments tys = List.map (this # typ) tys
+#endif
 
     method constructor_declaration {pcd_name; pcd_args; pcd_res; pcd_loc;
                                     pcd_attributes} =
@@ -534,7 +552,9 @@ class mapper =
       | PStr x -> PStr (this # structure x)
       | PTyp x -> PTyp (this # typ x)
       | PPat (x, g) -> PPat (this # pat x, map_opt (this # expr) g)
+#if OCAML_VERSION >= "4.03"
       | PSig x -> PSig (this # signature x)
+#endif
   end
 
 

--- a/ast_mapper_class.mli
+++ b/ast_mapper_class.mli
@@ -21,7 +21,11 @@ class mapper:
     method class_type: class_type -> class_type
     method class_type_declaration: class_type_declaration -> class_type_declaration
     method class_type_field: class_type_field -> class_type_field
+#if OCAML_VERSION >= "4.03"
     method constructor_arguments: constructor_arguments -> constructor_arguments
+#else
+   method constructor_arguments: core_type list -> core_type list
+#endif
     method constructor_declaration: constructor_declaration -> constructor_declaration
     method expr: expression -> expression
     method extension: extension -> extension
@@ -52,5 +56,4 @@ class mapper:
   end
 
 val to_mapper: #mapper -> Ast_mapper.mapper
-(** The resulting mapper is "closed", i.e. methods ignore
-    their first argument. *)
+(** The resulting mapper is "closed", i.e. methods ignore their first argument. *)

--- a/build.ocp
+++ b/build.ocp
@@ -1,0 +1,44 @@
+
+pp = "ocp-pp"
+
+  begin library "ppx_tools"
+      files = [ "ast_convenience.ml" "ast_mapper_class.ml" ]
+      requires = [ "compiler-libs.bytecomp" ]
+  end
+
+  begin program "genlifter"
+      files = [ "genlifter.ml" ]
+      requires = [ "ppx_tools" ]
+
+
+  build_rules = [
+    "ast_lifter.ml" (
+      sources = [ "%{genlifter_FULL_DST_DIR}%/genlifter.byte" ]
+        commands = [
+          { "%{genlifter_FULL_DST_DIR}%/genlifter.byte"
+              "-I" "%{OCAMLLIB}%/compiler-libs"
+              "-I" "%{OCAMLLIB}%"
+              "Parsetree.expression" } (stdout = "ast_lifter.ml" )
+        ]
+
+    )
+  ]
+
+  end
+
+
+  begin program "dumpast"
+      files = [ "ast_lifter.ml" "dumpast.ml" ]
+      requires = [ "ppx_tools" ]
+  end
+
+
+  begin program "ppx_metaquot"
+      files = [ "ast_lifter.ml" "ppx_metaquot.ml" ]
+      requires = [ "ppx_tools" ]
+  end
+
+  begin program "rewriter"
+      files = [ "rewriter.ml" ]
+      requires = [ "ppx_tools" ]
+  end

--- a/build.ocp
+++ b/build.ocp
@@ -1,44 +1,46 @@
 
-pp = "ocp-pp"
 
-  begin library "ppx_tools"
-      files = [ "ast_convenience.ml" "ast_mapper_class.ml" ]
-      requires = [ "compiler-libs.bytecomp" ]
-  end
+comp = [ "-w" "+A-4-17-44-45" ];
+if ocaml_version >= "4.02" then {
+  comp += [ "-safe-string" ];
+}
 
-  begin program "genlifter"
-      files = [ "genlifter.ml" ]
-      requires = [ "ppx_tools" ]
+pp = "ocp-pp";
 
+begin library "ppx_tools";
+  files = [ "ast_convenience.ml" "ast_mapper_class.ml" ];
+  requires = [ "compiler-libs.bytecomp" ];
+end;
+
+begin program "genlifter";
+  files = [ "genlifter.ml" ];
+  requires = [ "ppx_tools" ];
 
   build_rules = [
     "ast_lifter.ml" (
-      sources = [ "%{genlifter_FULL_DST_DIR}%/genlifter.byte" ]
-        commands = [
-          { "%{genlifter_FULL_DST_DIR}%/genlifter.byte"
-              "-I" "%{OCAMLLIB}%/compiler-libs"
-              "-I" "%{OCAMLLIB}%"
-              "Parsetree.expression" } (stdout = "ast_lifter.ml" )
-        ]
-
+      sources = [ "%{genlifter_FULL_DST_DIR}%/genlifter.byte" ];
+      commands = [
+        { "%{genlifter_FULL_DST_DIR}%/genlifter.byte"
+            "-I" "%{OCAMLLIB}%/compiler-libs"
+            "-I" "%{OCAMLLIB}%"
+            "Parsetree.expression" } (stdout = "ast_lifter.ml" )
+      ]
     )
-  ]
+  ];
 
-  end
+end;
 
+begin program "dumpast";
+  files = [ "ast_lifter.ml" "dumpast.ml" ];
+  requires = [ "ppx_tools" ];
+end;
 
-  begin program "dumpast"
-      files = [ "ast_lifter.ml" "dumpast.ml" ]
-      requires = [ "ppx_tools" ]
-  end
+begin program "ppx_metaquot";
+  files = [ "ast_lifter.ml" "ppx_metaquot.ml" ];
+  requires = [ "ppx_tools" ];
+end;;
 
-
-  begin program "ppx_metaquot"
-      files = [ "ast_lifter.ml" "ppx_metaquot.ml" ]
-      requires = [ "ppx_tools" ]
-  end
-
-  begin program "rewriter"
-      files = [ "rewriter.ml" ]
-      requires = [ "ppx_tools" ]
-  end
+begin program "rewriter";
+  files = [ "rewriter.ml" ];
+  requires = [ "ppx_tools" ];
+end;

--- a/dumpast.ml
+++ b/dumpast.ml
@@ -54,7 +54,9 @@ let show_pat = show (lift # lift_Parsetree_pattern) Parse.pattern
 let show_typ = show (lift # lift_Parsetree_core_type) Parse.core_type
 
 let show_file fn =
+#if OCAML_VERSION >= "4.03"
   Compenv.readenv Format.err_formatter (Compenv.Before_compile fn);
+#endif
   let v =
     if Filename.check_suffix fn ".mli" then
       let ast = Pparse.parse_interface ~tool_name:"ocamlc" Format.err_formatter fn in

--- a/opam
+++ b/opam
@@ -11,5 +11,6 @@ install: [[make "install"]]
 remove: [["ocamlfind" "remove" "ppx_tools"]]
 depends: [
   "ocamlfind" {>= "1.5.0"}
+  "ocp-build" {>= "1.99.17-beta"}
 ]
-available: ocaml-version >= "4.03.0"
+available: ocaml-version >= "4.02.0"

--- a/ppx_metaquot.ml
+++ b/ppx_metaquot.ml
@@ -59,6 +59,19 @@
 
 *)
 
+#if OCAML_VERSION < "4.03"
+
+module Const = struct
+
+  let int32 x = Asttypes.Const_int32 x
+  let int64 x = Asttypes.Const_int64 x
+  let nativeint x = Asttypes.Const_nativeint x
+
+  end
+
+#endif
+
+
 module Main : sig end = struct
   open Asttypes
   open Parsetree
@@ -73,7 +86,8 @@ module Main : sig end = struct
 
   let append ?loc ?attrs e e' =
     let fn = Location.mknoloc (Longident.(Ldot (Lident "List", "append"))) in
-    Exp.apply ?loc ?attrs (Exp.ident fn) [Nolabel, e; Nolabel, e']
+    Exp.apply ?loc ?attrs (Exp.ident fn)
+      [Label.explode Label.Nolabel, e; Label.explode Label.Nolabel, e']
 
   class exp_builder =
     object
@@ -218,10 +232,12 @@ module Main : sig end = struct
                (exp_lifter !loc this) # lift_Parsetree_structure e
            | Pexp_extension({txt="stri";_}, PStr [e]) ->
                (exp_lifter !loc this) # lift_Parsetree_structure_item e
+#if OCAML_VERSION >= "4.03"
            | Pexp_extension({txt="sig";_}, PSig e) ->
                (exp_lifter !loc this) # lift_Parsetree_signature e
            | Pexp_extension({txt="sigi";_}, PSig [e]) ->
                (exp_lifter !loc this) # lift_Parsetree_signature_item e
+#endif
            | Pexp_extension({txt="type";loc=l}, e) ->
                (exp_lifter !loc this) # lift_Parsetree_core_type (get_typ l e)
            | _ ->
@@ -239,10 +255,12 @@ module Main : sig end = struct
                (pat_lifter this) # lift_Parsetree_structure e
            | Ppat_extension({txt="stri";_}, PStr [e]) ->
                (pat_lifter this) # lift_Parsetree_structure_item e
+#if OCAML_VERSION >= "4.03"
            | Ppat_extension({txt="sig";_}, PSig e) ->
                (pat_lifter this) # lift_Parsetree_signature e
            | Ppat_extension({txt="sigi";_}, PSig [e]) ->
                (pat_lifter this) # lift_Parsetree_signature_item e
+#endif
            | Ppat_extension({txt="type";loc=l}, e) ->
                (pat_lifter this) # lift_Parsetree_core_type (get_typ l e)
            | _ ->


### PR DESCRIPTION
Provide compatibility from 4.02.0 to 4.03.0 using `ocp-pp` (included in `ocp-build`)
